### PR TITLE
Update C API usage (SVM v0.0.29)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@ all: install build
 .PHONY: all
 
 ARTIFACTS_DIR := $(realpath svm)/artifacts
-SVM_VERSION := 0.0.24
+SVM_VERSION := 0.0.29
 
 export GOOS
 export GOARCH

--- a/README.md
+++ b/README.md
@@ -262,12 +262,12 @@ svm-cli tx --tx-type=call --input=tx.json --output=tx.bin
 
 ### Init
 
-`Init` must be called at least once before interacting with any other API.
-The function is **idempotent** and won't do anything after the first call.
+`Init` is the entry point for interacting with SVM in any way. It runs internal
+initialization logic; it is fully thread-safe and idempotent.
 
 ```go
 
-func Init(inMemory bool, path string) error
+func Init() (*API, error)
 ```
 
 ### Creating a Runtime
@@ -278,7 +278,7 @@ Creates a new `SVM Runtime`. You can think of it as opening a connection to `SVM
 Here is the `Create Runtime` API:
 
 ```go
-func NewRuntime() (*Runtime, error)
+func (*API) NewRuntime() (*Runtime, error)
 ```
 
 ### Destroying a Runtime
@@ -529,7 +529,7 @@ This helper function is intended to be used for testing purposes. However, it co
 The API:
 
 ```go
-func RuntimesCount() int
+func (*API) RuntimesCount() int
 ```
 
 ### Receipts Count
@@ -543,7 +543,7 @@ The helper should be applied for testing purposes. However, the production code 
 The API:
 
 ```go
-func ReceiptsCount()
+func (*API) ReceiptsCount() int
 ```
 
 ### Errors Count

--- a/svm/api_test.go
+++ b/svm/api_test.go
@@ -14,9 +14,10 @@ func readFile(t *testing.T, path string) []byte {
 }
 
 func runtimeSetup(t *testing.T) *Runtime {
-	Init(true, "")
+	api, err := Init()
+	assert.Nil(t, err)
 
-	rt, err := NewRuntime()
+	rt, err := api.NewRuntime(true, "")
 	assert.NotNil(t, rt)
 	assert.Nil(t, err)
 
@@ -83,20 +84,21 @@ func call(t *testing.T, rt *Runtime, path string, params *TestParams) (*CallRece
 	return receipt.(*CallReceipt), err
 }
 
-func TestInitMemoryNilErr(t *testing.T) {
-	assert.Equal(t, 0, RuntimesCount())
-	err := Init(true, "")
+func TestInitNilErr(t *testing.T) {
+	_, err := Init()
 	assert.Nil(t, err)
-	assert.Equal(t, 0, RuntimesCount())
 }
 
 func TestNewRuntime(t *testing.T) {
-	assert.Equal(t, 0, RuntimesCount())
+	api, err := Init()
+	assert.Nil(t, err)
+
+	assert.Equal(t, 0, api.RuntimesCount())
 	rt := runtimeSetup(t)
 
-	assert.Equal(t, 1, RuntimesCount())
+	assert.Equal(t, 1, api.RuntimesCount())
 	rt.Destroy()
-	assert.Equal(t, 0, RuntimesCount())
+	assert.Equal(t, 0, api.RuntimesCount())
 }
 
 func TestValidateEmptyDeploy(t *testing.T) {


### PR DESCRIPTION
Makes `go-svm` APIs more type-safe via `*API`. See https://github.com/spacemeshos/svm/pull/432.