### PR TITLE
SVM v0.0.31: `svm_create_genesis_account` & `FuncNotCtor`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@ all: install build
 .PHONY: all
 
 ARTIFACTS_DIR := $(realpath svm)/artifacts
-SVM_VERSION := 0.0.30
+SVM_VERSION := 0.0.31
 
 export GOOS
 export GOARCH

--- a/svm/api.go
+++ b/svm/api.go
@@ -319,7 +319,7 @@ func (rt *Runtime) GetAccount(addr Address) (Account, error) {
 }
 
 func (rt *Runtime) CreateAccount(account Account) error {
-	res := C.svm_create_account(
+	res := C.svm_create_genesis_account(
 		rt.raw,
 		(*C.uchar)(unsafe.Pointer(&account.Addr[0])),
 		C.uint64_t(account.Balance),

--- a/svm/api_test.go
+++ b/svm/api_test.go
@@ -290,7 +290,7 @@ func TestSpawnNonexistentCtor(t *testing.T) {
 	assert.Nil(t, err)
 	assert.False(t, receipt.Success)
 	assert.NotNil(t, receipt.Error)
-	assert.Equal(t, receipt.Error.Kind, RuntimeErrorKind(FuncNotAllowed))
+	assert.Equal(t, receipt.Error.Kind, RuntimeErrorKind(FuncNotCtor))
 }
 
 func TestSpawnCtorExistsButInvalid(t *testing.T) {
@@ -303,7 +303,7 @@ func TestSpawnCtorExistsButInvalid(t *testing.T) {
 	assert.Nil(t, err)
 	assert.False(t, receipt.Success)
 	assert.NotNil(t, receipt.Error)
-	assert.Equal(t, receipt.Error.Kind, RuntimeErrorKind(FuncNotAllowed))
+	assert.Equal(t, receipt.Error.Kind, RuntimeErrorKind(FuncNotCtor))
 }
 
 func TestCallNonexistentFunc(t *testing.T) {

--- a/svm/error.go
+++ b/svm/error.go
@@ -17,8 +17,9 @@ const (
 	InstantiationFailed  RuntimeErrorKind = 4
 	FuncNotFound         RuntimeErrorKind = 5
 	FuncFailed           RuntimeErrorKind = 6
-	FuncNotAllowed       RuntimeErrorKind = 7
-	FuncInvalidSignature RuntimeErrorKind = 8
+	FuncNotCtor          RuntimeErrorKind = 7
+	FuncNotAllowed       RuntimeErrorKind = 8
+	FuncInvalidSignature RuntimeErrorKind = 9
 )
 
 type ValidateError struct {

--- a/svm/receipt.go
+++ b/svm/receipt.go
@@ -89,6 +89,12 @@ func decodeRuntimeError(bytes []byte) (*RuntimeError, []Log, error) {
 		rtError.Target = target
 		rtError.Function = function
 		return rtError, logs, nil
+	case RuntimeErrorKind(FuncNotCtor):
+		template, bytes := decodeAddress(bytes)
+		function, bytes := decodeString(bytes)
+		rtError.Template = template
+		rtError.Function = function
+		return rtError, logs, nil
 	case RuntimeErrorKind(FuncFailed), RuntimeErrorKind(FuncNotAllowed):
 		template, bytes := decodeAddress(bytes)
 		target, bytes := decodeAddress(bytes)


### PR DESCRIPTION
`svm_create_account` becomes `svm_create_genesis_account` for clarity: it should only be used for genesis initialization. See https://github.com/spacemeshos/go-svm/issues/19. Also add support for `FuncNotCtor`.